### PR TITLE
Fix scheduler forward declarations

### DIFF
--- a/kernel/core/scheduler.c
+++ b/kernel/core/scheduler.c
@@ -35,13 +35,13 @@ static message_t message_pool[MAX_MESSAGES];
 static bool message_pool_used[MAX_MESSAGES];
 
 // Internal function prototypes
-static actor_t* scheduler_select_next_actor(void);
-static void scheduler_context_switch(actor_t* next_actor);
-static void scheduler_add_to_ready_queue(actor_t* actor);
-static void scheduler_remove_from_ready_queue(actor_t* actor);
+static struct actor_context* scheduler_select_next_actor(void);
+static void scheduler_context_switch(struct actor_context* next_actor);
+static void scheduler_add_to_ready_queue(struct actor_context* actor);
+static void scheduler_remove_from_ready_queue(struct actor_context* actor);
 static void actor_create_kernel_actor(void);
-static bool actor_add_message(actor_t* actor, message_t* message);
-static void actor_clear_message_queue(actor_t* actor);
+static bool actor_add_message(struct actor_context* actor, message_t* message);
+static void actor_clear_message_queue(struct actor_context* actor);
 static message_t* message_allocate(void);
 
 // =============================================================================

--- a/kernel/core/scheduler.c
+++ b/kernel/core/scheduler.c
@@ -34,6 +34,16 @@ static bool actor_pool_used[MAX_ACTORS];
 static message_t message_pool[MAX_MESSAGES];
 static bool message_pool_used[MAX_MESSAGES];
 
+// Internal function prototypes
+static actor_t* scheduler_select_next_actor(void);
+static void scheduler_context_switch(actor_t* next_actor);
+static void scheduler_add_to_ready_queue(actor_t* actor);
+static void scheduler_remove_from_ready_queue(actor_t* actor);
+static void actor_create_kernel_actor(void);
+static bool actor_add_message(actor_t* actor, message_t* message);
+static void actor_clear_message_queue(actor_t* actor);
+static message_t* message_allocate(void);
+
 // =============================================================================
 // Core Scheduler Functions
 // =============================================================================

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -77,8 +77,8 @@ typedef struct {
 // Async Actor System Definitions (Forward Declaration)
 // =============================================================================
 
-// Forward declarations - actual definitions in scheduler.h
-typedef struct actor_context actor_t;
+// Forward declaration - actual definition in scheduler.h
+struct actor_context;
 
 // =============================================================================
 // Memory Management Definitions


### PR DESCRIPTION
## Summary
- add internal prototypes in scheduler to prevent implicit declarations
- replace duplicate actor typedef with forward declaration

## Testing
- `make kernel` *(fails: unknown type name `paging_context_t`)*

------
https://chatgpt.com/codex/tasks/task_e_6897d3a2dd24832c90f95ffcfcf47647